### PR TITLE
Support address

### DIFF
--- a/Localide.podspec
+++ b/Localide.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Localide"
-  s.version      = "2.1.0"
+  s.version      = "2.2.0"
   s.summary      = "Localide is an easy helper to offer users a personalized experience by using their favorite installed apps for directions."
 
   s.homepage     = "https://github.com/davoda/Localide"

--- a/Localide/Classes/LocalideMapApp.swift
+++ b/Localide/Classes/LocalideMapApp.swift
@@ -9,7 +9,7 @@
 import UIKit
 import CoreLocation
 
-public enum LocalideMapApp: Int {
+@objc public enum LocalideMapApp: Int {
     case appleMaps = 10
     case citymapper = 20
     case googleMaps = 30
@@ -37,7 +37,7 @@ public enum LocalideMapApp: Int {
         }
     }
 
-    internal static let AllMapApps: [LocalideMapApp] = [appleMaps, citymapper, googleMaps, navigon, transitApp, waze, yandexNavigator]
+    static let AllMapApps: [LocalideMapApp] = [appleMaps, citymapper, googleMaps, navigon, transitApp, waze, yandexNavigator]
 }
 
 // MARK: - Public Helpers


### PR DESCRIPTION
extended class to support address navigation
notice that not all localized map apps actually support 
navigating by address (so there is fallback code to coordinate in such cases
also Localide doesn't support Objective C at all. 
so i used @orxelm own fork to copy his implementation for supporting Objc